### PR TITLE
Fix qiskit requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Topic :: Scientific/Engineering",
     ],
-    install_requires=['qiskit>=0.7'],
+    install_requires=['qiskit-terra>=0.7'],
     keywords="qiskit quantum jku_simulator",
     packages=find_packages(exclude=['test*']),
     include_package_data=True,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The JKU provider currently says it requires the 'qiskit' package,
however this is not correct. The 'qiskit' package is just a
meta-package for installation convenience that will install all the
qiskit elements. The JKU provider actually depends on qiskit-terra which
is the package for the terra code. Having this incorrect causes the
metapackage to be installed which forces specific versions of the
elements to be installed, see Qiskit/qiskit#222 for the issues this
can cause.


### Details and comments


