### PR TITLE
Added paragraph to README for retirement of qiskit-jku-provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# Qiskit JKU Simulator Provider is superseded by [JKQ DDSIM](https://github.com/iic-jku/ddsim)
+
+The Qiskit JKU Simulator is superseded by [JKQ DDSIM](https://github.com/iic-jku/ddsim), which uses a reworked 
+implementation of the underlying decision diagrams as well as pybind11 (instead of writing OpenQASM code to files).
+Existing code can be adapted with minimal changes (import statements and provider name), new code should use the JKQ DDSIM
+from start. Python wheels are available via PyPI as [jkq.ddsim](https://pypi.org/project/jkq.ddsim/).
+
 # Qiskit JKU Simulator Provider
 
 [![License](https://img.shields.io/github/license/Qiskit/qiskit-jku-provider.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)[![Build Status](https://img.shields.io/travis/com/Qiskit/qiskit-jku-provider/master.svg?style=popout-square)](https://travis-ci.com/Qiskit/qiskit-jku-provider)[![](https://img.shields.io/github/release/Qiskit/qiskit-jku-provider.svg?style=popout-square)](https://github.com/Qiskit/qiskit-jku-provider/releases)[![](https://img.shields.io/pypi/dm/qiskit-jku-provider.svg?style=popout-square)](https://pypi.org/project/qiskit-jku-provider/)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ implementation of the underlying decision diagrams as well as pybind11 (instead 
 Existing code can be adapted with minimal changes (import statements and provider name), new code should use the JKQ DDSIM
 from start. Python wheels are available via PyPI as [jkq.ddsim](https://pypi.org/project/jkq.ddsim/).
 
+The *Getting Started* example listed below would need the following changes:
+
+* `pip install qiskit-jku-provider` → `pip install jkq.ddsim`
+* `from qiskit_jku_provider import JKUProvider` → `from jkq import ddsim`
+* `JKU = JKUProvider()` → `JKU = ddsim.JKQProvider()`
+* Optional, but recommended: Rename variables containing `jku` to contain `jkq` instead.
+
+
 # Qiskit JKU Simulator Provider
 
 [![License](https://img.shields.io/github/license/Qiskit/qiskit-jku-provider.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)[![Build Status](https://img.shields.io/travis/com/Qiskit/qiskit-jku-provider/master.svg?style=popout-square)](https://travis-ci.com/Qiskit/qiskit-jku-provider)[![](https://img.shields.io/github/release/Qiskit/qiskit-jku-provider.svg?style=popout-square)](https://github.com/Qiskit/qiskit-jku-provider/releases)[![](https://img.shields.io/pypi/dm/qiskit-jku-provider.svg?style=popout-square)](https://pypi.org/project/qiskit-jku-provider/)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The qiskit-jku-provider is based on an out-dated implementation of the JKU simulator. The recent version is available as [JKQ DDSIM](https://github.com/iic-jku/ddsim).

I would suggest archiving this repository and adding a few lines of text of explanation with this PR.

JKQ DDSIM should be faster (although I haven't directly compared to the code in this repository) and it should be easier to maintain and extend. For example, a backend to construct the unitary is available.

Corresponding Slack Thread: https://qiskit.slack.com/archives/C7SS31917/p1620994583241400

### Details and comments

Apart from not being actively maintained, the qiskit-jku-provider uses an out-dated implementation of the underlying decision diagrams as well as the simulation front-end. Additionally, the bindings between python and c++ are realized by writing to files from python, reading them in c++, and reading back the c++ output to python---the new implementation used pybind11.


